### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,3 +152,23 @@ Inside `packages/lingo/` the same scripts run directly (`bun run test`, etc.).
 - Re-read the original request every few turns to make sure you haven't drifted.
 - When the user corrects you, stop and re-read their message before continuing.
 - Don't write new comments unless they state a constraint the code can't show.
+
+## Cursor Cloud specific instructions
+
+The startup update script runs `bun install` (Bun 1.3.14 lives at `~/.bun/bin`,
+already on `PATH` via `~/.bashrc`). Commands, module map, and site notes are all
+documented above — this section only records cloud-specific gotchas.
+
+- **No external services.** No DB / cache / API keys. The library is in-process;
+  tests are Vitest + jsdom; `ai-eval` runs a recorded corpus. `bun run check`
+  needs nothing long-lived; browser E2E needs `bun dev` (see Commands above).
+- **`bun dev` runs both packages via turbo:** `tsup --watch` (library, no port)
+  and Next dev (`lingo-site`, port 3000, auto-increments if busy — read the log
+  for the actual port). Verify with `curl -I http://localhost:3000/`.
+- **lefthook postinstall is expected to no-op here.** The root `postinstall`
+  prints a `core.hooksPath is set locally … Custom hooks paths are not supported`
+  warning because Cursor manages git hooks; it exits `|| true`, so install still
+  succeeds. Don't "fix" it.
+- **Noisy but harmless build output.** `tsup` emits many Rollup warnings
+  ("reexported through module … circular dependency", "named and default exports
+  together"). These are pre-existing; the build still reports `Build success`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the `lingo` Bun monorepo in Cursor Cloud and verifies it end-to-end.

- Installs Bun 1.3.14 (the pinned `packageManager`) and runs `bun install` (startup update script).
- Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` capturing durable, non-obvious caveats (no external services; `bun dev` runs `tsup --watch` + Next on port 3000; the expected lefthook postinstall no-op; harmless Rollup build warnings).

## Verification

- `bun run lint` — clean (268 files, no fixes).
- `bun run check` — typecheck + tests + build + size budgets + corpus/docs/zero-deps/schema gates all pass.
- `bun dev` — library watch built successfully; Next site ready on `http://localhost:3000` (HTTP 200).
- Hello-world: typed natural-language quantities into the live parser demo — `72 in to cm` → `182.88 cm`; `between 5 and 10 kg` → `5-10 kg`.

[lingo_parser_demo.mp4](https://cursor.com/agents/bc-510f9c2a-d54e-439d-80be-f26fe6c40fe6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flingo_parser_demo.mp4)

[72 in to cm parsed to 182.88 cm](https://cursor.com/agents/bc-510f9c2a-d54e-439d-80be-f26fe6c40fe6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flingo_convert_72in_to_cm.webp)
[between 5 and 10 kg parsed to 5-10 kg range](https://cursor.com/agents/bc-510f9c2a-d54e-439d-80be-f26fe6c40fe6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flingo_range_5_to_10_kg.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-510f9c2a-d54e-439d-80be-f26fe6c40fe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-510f9c2a-d54e-439d-80be-f26fe6c40fe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

